### PR TITLE
Fixing relocation issue

### DIFF
--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCCodeEmitter.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCCodeEmitter.cpp
@@ -86,7 +86,7 @@ unsigned MOSMCCodeEmitter::encodeImm(const MCInst &MI, unsigned OpNo,
 unsigned MOSMCCodeEmitter::getExprOpValue(const MCExpr *Expr,
                                           SmallVectorImpl<MCFixup> &Fixups,
                                           const MCSubtargetInfo &STI,
-                                          unsigned int off ) const {
+                                          unsigned int Offset ) const {
 
   MCExpr::ExprKind Kind = Expr->getKind();
 
@@ -103,7 +103,7 @@ unsigned MOSMCCodeEmitter::getExprOpValue(const MCExpr *Expr,
     }
 
     MCFixupKind FixupKind = static_cast<MCFixupKind>(MOSExpr->getFixupKind());
-    Fixups.push_back(MCFixup::create(off, MOSExpr, FixupKind));
+    Fixups.push_back(MCFixup::create(Offset, MOSExpr, FixupKind));
     return 0;
   }
 

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCCodeEmitter.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCCodeEmitter.cpp
@@ -70,7 +70,7 @@ unsigned MOSMCCodeEmitter::encodeImm(const MCInst &MI, unsigned OpNo,
       // we shouldn't perform any more fixups. Without this check, we would
       // instead create a fixup to the symbol named 'lo8(symbol)' which
       // is not correct.
-      return getExprOpValue(MO.getExpr(), Fixups, STI);
+      return getExprOpValue(MO.getExpr(), Fixups, STI, Offset);
     }
 
     MCFixupKind FixupKind = static_cast<MCFixupKind>(Fixup);
@@ -85,7 +85,8 @@ unsigned MOSMCCodeEmitter::encodeImm(const MCInst &MI, unsigned OpNo,
 
 unsigned MOSMCCodeEmitter::getExprOpValue(const MCExpr *Expr,
                                           SmallVectorImpl<MCFixup> &Fixups,
-                                          const MCSubtargetInfo &STI) const {
+                                          const MCSubtargetInfo &STI,
+                                          unsigned int off ) const {
 
   MCExpr::ExprKind Kind = Expr->getKind();
 
@@ -102,7 +103,7 @@ unsigned MOSMCCodeEmitter::getExprOpValue(const MCExpr *Expr,
     }
 
     MCFixupKind FixupKind = static_cast<MCFixupKind>(MOSExpr->getFixupKind());
-    Fixups.push_back(MCFixup::create(0, MOSExpr, FixupKind));
+    Fixups.push_back(MCFixup::create(off, MOSExpr, FixupKind));
     return 0;
   }
 

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCCodeEmitter.h
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCCodeEmitter.h
@@ -86,7 +86,7 @@ private:
                                  const MCSubtargetInfo &STI) const;
 
   unsigned getExprOpValue(const MCExpr *Expr, SmallVectorImpl<MCFixup> &Fixups,
-                          const MCSubtargetInfo &STI, unsigned int off ) const;
+                          const MCSubtargetInfo &STI, unsigned int Offset ) const;
 
   /// Returns the binary encoding of operand.
   ///

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSMCCodeEmitter.h
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSMCCodeEmitter.h
@@ -86,7 +86,7 @@ private:
                                  const MCSubtargetInfo &STI) const;
 
   unsigned getExprOpValue(const MCExpr *Expr, SmallVectorImpl<MCFixup> &Fixups,
-                          const MCSubtargetInfo &STI) const;
+                          const MCSubtargetInfo &STI, unsigned int off ) const;
 
   /// Returns the binary encoding of operand.
   ///


### PR DESCRIPTION
Patch to Issue #2

Comment in `encodeImm` says, that we shouldn't perform any more fixups if the expression is already a `MOSMCExpr`. `getExprOpValue` is called then but it does perform a fixup with default offset.
This patch only forwards offset between these two functions which works for `mos16lo`/`mos16hi` expressions. I'm not sure whether there aren't any other viable scenarios in which this might mess up things.