### PR TITLE
zero-page section flag

### DIFF
--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1001,7 +1001,10 @@ enum : unsigned {
   SHF_MIPS_STRING = 0x80000000,
 
   // Make code section unreadable when in execute-only mode
-  SHF_ARM_PURECODE = 0x20000000
+  SHF_ARM_PURECODE = 0x20000000,
+
+  // 8-bit addressable section
+  SHF_MOS_ZEROPAGE = 0x10000000
 };
 
 // Section Group Flags

--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -326,6 +326,9 @@ static unsigned parseSectionFlags(StringRef flagsStr, bool *UseLastGroup) {
     case 'G':
       flags |= ELF::SHF_GROUP;
       break;
+    case 'z':
+      flags |= ELF::SHF_MOS_ZEROPAGE;
+      break;
     case '?':
       *UseLastGroup = true;
       break;

--- a/llvm/lib/MC/MCSectionELF.cpp
+++ b/llvm/lib/MC/MCSectionELF.cpp
@@ -116,6 +116,9 @@ void MCSectionELF::PrintSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
   } else if (Arch == Triple::hexagon) {
     if (Flags & ELF::SHF_HEX_GPREL)
       OS << 's';
+  } else if (Arch == Triple::mos) {
+    if (Flags & ELF::SHF_MOS_ZEROPAGE)
+      OS << 'z';
   }
 
   OS << '"';

--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -553,6 +553,9 @@ void ScalarBitSetTraits<ELFYAML::ELF_SHF>::bitset(IO &IO,
   case ELF::EM_X86_64:
     BCase(SHF_X86_64_LARGE);
     break;
+  case ELF::EM_MOS:
+    BCase(SHF_MOS_ZEROPAGE);
+    break;
   default:
     // Nothing to do.
     break;

--- a/llvm/lib/Target/MOS/MCTargetDesc/MOSAsmBackend.cpp
+++ b/llvm/lib/Target/MOS/MCTargetDesc/MOSAsmBackend.cpp
@@ -231,6 +231,11 @@ bool MOSAsmBackend::fixupNeedsRelaxationAdvanced(const MCFixup &Fixup,
       if (ELFSection == nullptr) {
         return true;
       }
+      /// If the section of the symbol is marked with special zero-page flag
+      /// then this is an 8 bit instruction and it doesn't need relaxation.
+      if ( ( ELFSection->getFlags() & ELF::SHF_MOS_ZEROPAGE ) != 0 ) {
+        return false;
+      }
       const auto &ELFSectionName = ELFSection->getSectionName();
       /// If the section of the symbol is one of the prenamed zero page
       /// sections, then this is an 8 bit instruction and it doesn't need

--- a/llvm/test/MC/MOS/zeropage.s
+++ b/llvm/test/MC/MOS/zeropage.s
@@ -1,0 +1,17 @@
+  .text
+
+  lda test1
+  lda test2
+  lda test3
+
+  .section .zp
+
+test1: .ds 1
+
+  .section nzp
+
+test2: .ds 1
+
+  .section customzp, "z"
+
+test3: .ds 1

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -1526,6 +1526,9 @@ static const EnumEntry<unsigned> ElfMipsSectionFlags[] = {
   ENUM_ENT(SHF_MIPS_STRING,  "")
 };
 
+static const EnumEntry<unsigned> ElfMOSSectionFlags[] = {
+    ENUM_ENT(SHF_MOS_ZEROPAGE, "z")};
+
 static const EnumEntry<unsigned> ElfX86_64SectionFlags[] = {
   ENUM_ENT(SHF_X86_64_LARGE, "l")
 };
@@ -1554,6 +1557,10 @@ getSectionFlagsForTarget(unsigned EMachine) {
   case EM_XCORE:
     Ret.insert(Ret.end(), std::begin(ElfXCoreSectionFlags),
                std::end(ElfXCoreSectionFlags));
+    break;
+  case EM_MOS:
+    Ret.insert(Ret.end(), std::begin(ElfMOSSectionFlags),
+               std::end(ElfMOSSectionFlags));
     break;
   default:
     break;
@@ -3620,6 +3627,8 @@ static void printSectionDescription(formatted_raw_ostream &OS,
     OS << "  l (large), ";
   else if (EMachine == EM_ARM)
     OS << "  y (purecode), ";
+  else if (EMachine == EM_MOS)
+    OS << "  z (zeropage), ";
   else
     OS << "  ";
 


### PR DESCRIPTION
As a follow-up of a [forum duscussion](http://forum.6502.org/viewtopic.php?f=2&t=6241&start=15#p78182) I've prepared a minimal proposal for zero-page section flag.
It's a pull request, but I don't insist on pulling it. It's just a proof of concept.

pros:
- it works
- it permits to have multiple different sections on page zero with different semantics
- it's not a precedence. There is already for example flag `SHF_ARM_PURECODE` with flag letter "y"

cons:
LLVM architecture is poorly suited to such actions and it must be done globally. E.g. the 'z' flag that I've used will work for any other machine as ElfArmParser does not check triples and does not forward unknown flags to target parsers. And vice versa - other flags for other machines can be interpreted as `SHF_MOS_ZEROPAGE` in MOSBackend if it happens to use the same bit. It can be easily done better in this place but in other places flags are treated globally too and handling it in implementations of specific machines needs heavy lifting. 
